### PR TITLE
emit empty line after MODULE directive

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension ExtUtils::XSpp.
 
+	- Added --no-exceptions command line option.
+
 0.18  Wed Sep 18 10:00:00 CEST 2013
 	- Upgrade to stable release.
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -60,6 +60,7 @@ lib/ExtUtils/XSpp/Node/Type.pm
 lib/ExtUtils/XSpp/Parser.pm
 lib/ExtUtils/XSpp/Plugin.pod
 lib/ExtUtils/XSpp/Plugin/feature/default_xs_typemap.pm
+lib/ExtUtils/XSpp/Plugin/feature/renamed_types_typemap.pm
 lib/ExtUtils/XSpp/Typemap.pm
 lib/ExtUtils/XSpp/Typemap/parsed.pm
 lib/ExtUtils/XSpp/Typemap/reference.pm

--- a/MANIFEST
+++ b/MANIFEST
@@ -84,6 +84,7 @@ t/022_virtual.t
 t/023_base_classes.t
 t/024_enum.t
 t/025_member.t
+t/026_thx.t
 t/030_code_blocks.t
 t/031_verbatim_blocks.t
 t/035_include.t

--- a/XSP.yp
+++ b/XSP.yp
@@ -138,16 +138,28 @@ enum_element:
     | raw
     ;
 
-class:    class_decl SEMICOLON | decorate_class SEMICOLON;
+class:    class_decl SEMICOLON;
 function: function_decl SEMICOLON;
 method:   method_decl SEMICOLON;
 member:   member_decl SEMICOLON;
 
-decorate_class:
-    perc_name class_decl { $_[2]->set_perl_name( $_[1] ); $_[2] };
+perc_name_and_type:
+      type           { [undef, $_[1]] }
+    | perc_name type { [$_[1], $_[2]] }
+    ;
 
-class_decl: 'class' class_name base_classes class_metadata OPCURLY class_body_list CLCURLY
-                { create_class( $_[0], $_[2], $_[3], $_[4], $_[6],
+class_start:
+      'class'           { undef }
+    | perc_name 'class' { $_[1] }
+    ;
+
+virtual_start:
+      virtual           { undef }
+    | perc_name virtual { $_[1] }
+    ;
+
+class_decl: class_start class_name base_classes class_metadata OPCURLY class_body_list CLCURLY
+                { create_class( $_[0], $_[2], $_[1], $_[3], $_[4], $_[6],
                                 $_[0]->get_conditional ) };
 
 base_classes:
@@ -162,11 +174,8 @@ base_class:
     ;
 
 class_name_rename:
-      class_name           { create_class( $_[0], $_[1], [], [] ) }
-    | perc_name class_name { my $klass = create_class( $_[0], $_[2], [], [] );
-                             $klass->set_perl_name( $_[1] );
-                             $klass
-                             }
+      class_name           { create_class( $_[0], $_[1], undef, [], [] ) }
+    | perc_name class_name { create_class( $_[0], $_[2], $_[1], [], [] ) }
     ;
 
 class_metadata:   class_metadata perc_catch { [ @{$_[1]}, @{$_[2]} ] }
@@ -199,15 +208,11 @@ member_metadata: member_metadata _member_metadata { [ @{$_[1]}, @{$_[2]} ] }
 _member_metadata:    perc_any;
 
 member_decl:
-    | looks_like_member
-    | perc_name looks_like_member
-         { $_[2]->set_perl_name( $_[1] ); $_[2] };
-
-looks_like_member:
-      type ID member_metadata
+      perc_name_and_type ID member_metadata
           { create_member( $_[0],
                            name      => $_[2],
-                           type      => $_[1],
+                           perl_name => $_[1][0],
+                           type      => $_[1][1],
                            condition => $_[0]->get_conditional,
                            @{$_[3]} ) };
 
@@ -224,21 +229,17 @@ static: 'package_static'
       ;
 
 looks_like_function:
-      type function_name OPPAR arg_list CLPAR const
+      perc_name_and_type function_name OPPAR arg_list CLPAR const
           {
-              return { ret_type  => $_[1],
+              return { ret_type  => $_[1][1],
                        name      => $_[2],
+                       perl_name => $_[1][0],
                        arguments => $_[4],
                        const     => $_[6],
                        };
           };
 
-looks_like_renamed_function:
-      looks_like_function
-    | perc_name looks_like_function
-          { $_[2]->{perl_name} = $_[1]; $_[2] };
-
-function_decl:  looks_like_renamed_function function_metadata
+function_decl:  looks_like_function function_metadata
                     { add_data_function( $_[0],
                                          name      => $_[1]->{name},
                                          perl_name => $_[1]->{perl_name},
@@ -270,7 +271,7 @@ function_name:  ID
               | ID class_suffix { $_[1] . '::' . $_[2] };
 
 nmethod:
-      looks_like_renamed_function function_metadata
+      looks_like_function function_metadata
           { my $m = add_data_method
                         ( $_[0],
                           name      => $_[1]->{name},
@@ -287,17 +288,11 @@ nmethod:
           { $_[2]->set_static( $_[1] ); $_[2] };
 
 vmethod:
-      _vmethod
-    | perc_name vmethod
-          { $_[2]->set_perl_name( $_[1] ); $_[2] }
-    ;
-
-_vmethod:
-      virtual looks_like_function function_metadata
+      virtual_start looks_like_function function_metadata
           { my $m = add_data_method
                         ( $_[0],
                           name      => $_[2]->{name},
-                          perl_name => $_[2]->{perl_name},
+                          perl_name => $_[1] || $_[2]->{perl_name},
                           ret_type  => $_[2]->{ret_type},
                           arguments => $_[2]->{arguments},
                           const     => $_[2]->{const},
@@ -307,11 +302,11 @@ _vmethod:
             $m->set_virtual( 1 );
             $m
           }
-    | virtual looks_like_function EQUAL INTEGER function_metadata
+    | virtual_start looks_like_function EQUAL INTEGER function_metadata
           { my $m = add_data_method
                         ( $_[0],
                           name      => $_[2]->{name},
-                          perl_name => $_[2]->{perl_name},
+                          perl_name => $_[1] || $_[2]->{perl_name},
                           ret_type  => $_[2]->{ret_type},
                           arguments => $_[2]->{arguments},
                           const     => $_[2]->{const},

--- a/XSP.yp
+++ b/XSP.yp
@@ -408,12 +408,15 @@ file_name:      DASH                            { '-' }
               | ID SLASH file_name              { $_[1] . '/' . $_[3] };
 
 arg_list:       nonvoid_arg_list
-              | 'void'                  { undef };
+              | thx                     { [ $_[1] ] }
+              | 'void'                  { undef }
+              | ;
 
 nonvoid_arg_list:
     argument                            { [ $_[1] ] }
+  | thx_comma argument                  { [ $_[1], $_[2] ] }
   | nonvoid_arg_list COMMA argument     { push @{$_[1]}, $_[3]; $_[1] }
-  | ;
+  ;
 
 argument_metadata: argument_metadata _argument_metadata { [ @{$_[1]}, @{$_[2]} ] }
                  |                                      { [] }
@@ -427,6 +430,13 @@ argument:       type p_length OPCURLY ID CLCURLY
                     { make_argument( @_[0, 1, 2, 5], @{$_[3]} ) }
               | type ID argument_metadata
                     { make_argument( @_[0, 1, 2], undef, @{$_[3]} ) };
+
+thx: 'aTHX'         { make_thx() };
+
+thx_comma:
+    'aTHX_'         { make_thx() }
+  | 'aTHX' COMMA    { make_thx() }
+  ;
 
 value:          INTEGER
               | DASH INTEGER    { '-' . $_[2] }

--- a/XSP.yp
+++ b/XSP.yp
@@ -224,7 +224,7 @@ static: 'package_static'
       ;
 
 looks_like_function:
-      type ID OPPAR arg_list CLPAR const
+      type function_name OPPAR arg_list CLPAR const
           {
               return { ret_type  => $_[1],
                        name      => $_[2],
@@ -265,6 +265,9 @@ dtor:           TILDE ID OPPAR CLPAR function_metadata
 function_metadata:   function_metadata _function_metadata { [ @{$_[1]}, @{$_[2]} ] }
                    |                                      { [] }
                    ;
+
+function_name:  ID
+              | ID class_suffix { $_[1] . '::' . $_[2] };
 
 nmethod:
       looks_like_renamed_function function_metadata

--- a/lib/ExtUtils/XSpp.pod
+++ b/lib/ExtUtils/XSpp.pod
@@ -6,6 +6,7 @@ ExtUtils::XSpp - XS for C++
 
   xspp [--typemap=typemap.xsp [--typemap=typemap2.xsp]]
        [--xsubpp[=/path/to/xsubpp] [--xsubpp-args="xsubpp args"]
+       [--no-exceptions]
        Foo.xsp
 
 or
@@ -36,6 +37,11 @@ that in the I<TYPEMAPS> section below.
 Can be specified multiple times to process additional typemap files
 before the main XS++ input files.  Typemap files are processed the
 same way as regular XS++ files, except that output code is discarded.
+
+=head2 C<--no-exceptions>
+
+Disables generation of exception handling code.  XS++ syntax related
+to exceptions is accepted and ignored.
 
 =head2 C<--xsubpp[=/path/to/xsubpp]>
 

--- a/lib/ExtUtils/XSpp/Cmd.pm
+++ b/lib/ExtUtils/XSpp/Cmd.pm
@@ -32,8 +32,9 @@ use ExtUtils::XSpp::Driver;
 our @EXPORT = qw(xspp);
 
 sub xspp {
-    my( @typemap_files, $xsubpp, $xsubpp_args );
+    my( @typemap_files, $xsubpp, $xsubpp_args, $exceptions);
     GetOptions( 'typemap=s'       => \@typemap_files,
+                'exceptions!'     => \($exceptions = 1),
                 'xsubpp:s'        => \$xsubpp,
                 'xsubpp-args=s'   => \$xsubpp_args,
                 );
@@ -44,6 +45,7 @@ sub xspp {
         file        => shift @ARGV,
         xsubpp      => $xsubpp,
         xsubpp_args => $xsubpp_args,
+        exceptions  => $exceptions,
         );
     my $success = $driver->process ? 0 : 1;
 

--- a/lib/ExtUtils/XSpp/Driver.pm
+++ b/lib/ExtUtils/XSpp/Driver.pm
@@ -32,13 +32,9 @@ sub generate {
     my $typemap_code = ExtUtils::XSpp::Typemap::get_xs_typemap_code_for_all_typemaps();
     if (defined $typemap_code && $typemap_code =~ /\S/) {
         if (exists $generated->{'-'} and $generated->{'-'} ne '') {
-            $generated->{'-'} = $typemap_code . $generated->{'-'};
-        }
-        elsif (my @files = grep !/^-$/, keys %$generated) {
-            $generated->{$files[0]} = $typemap_code . ($generated->{$files[0]}||'');
-        }
-        else {
-            $generated->{'-'} = $typemap_code . ($generated->{'-'}||'');
+            $generated->{'-'} =~ s{^(MODULE=.*\n)$}{$1$typemap_code}m
+        } else {
+            $generated->{'-'} = $typemap_code;
         }
     }
 

--- a/lib/ExtUtils/XSpp/Lexer.pm
+++ b/lib/ExtUtils/XSpp/Lexer.pm
@@ -307,18 +307,19 @@ sub make_argument {
 }
 
 sub create_class {
-  my( $parser, $name, $bases, $metadata, $methods, $condition ) = @_;
+  my( $parser, $name, $perl_name, $bases, $metadata, $methods, $condition ) = @_;
   my %args = @$metadata;
   _merge_keys( 'catch', \%args, $metadata );
 
   my $class = ExtUtils::XSpp::Node::Class->new( %args, # <-- catch only for now
                                                 cpp_name     => $name,
+                                                perl_name    => $perl_name,
                                                 base_classes => $bases,
                                                 condition    => $condition,
                                                 );
 
   # when adding a class C, automatically add weak typemaps for C* and C&
-  ExtUtils::XSpp::Typemap::add_class_default_typemaps( $name );
+  ExtUtils::XSpp::Typemap::add_class_default_typemaps( $name, $perl_name );
 
   my @any  = grep  $_->isa( 'ExtUtils::XSpp::Node::PercAny' ), @$methods;
   my @rest = grep !$_->isa( 'ExtUtils::XSpp::Node::PercAny' ), @$methods;

--- a/lib/ExtUtils/XSpp/Lexer.pm
+++ b/lib/ExtUtils/XSpp/Lexer.pm
@@ -88,6 +88,8 @@ my %keywords = ( const           => 1,
                  protected       => 1,
                  virtual         => 1,
                  enum            => 1,
+                 aTHX            => 1,
+                 aTHX_           => 1,
                  );
 
 sub get_lex_mode { return $_[0]->YYData->{LEX}{MODES}[0] || '' }
@@ -302,6 +304,14 @@ sub make_argument {
                   name    => $name,
                   default => $default,
                   tags    => $args{tag} );
+
+  return $arg;
+}
+
+sub make_thx {
+  my $arg = ExtUtils::XSpp::Node::Argument->new
+                ( type    => undef,
+                  name    => 'aTHX' );
 
   return $arg;
 }

--- a/lib/ExtUtils/XSpp/Node/Class.pm
+++ b/lib/ExtUtils/XSpp/Node/Class.pm
@@ -221,6 +221,7 @@ sub methods { $_[0]->{METHODS} }
 sub base_classes { $_[0]->{BASE_CLASSES} }
 sub empty { !$_[0]->methods || !@{$_[0]->methods} }
 sub xs_class_name { $EnableRenamedTypes ? $_[0]->perl_name : $_[0]->cpp_name }
+sub type { ExtUtils::XSpp::Node::Type->new( base => $_[0]->cpp_name, pointer => 1 ) }
 
 sub _enable_renamed_types_typemaps {
   $EnableRenamedTypes = 1;

--- a/lib/ExtUtils/XSpp/Node/Class.pm
+++ b/lib/ExtUtils/XSpp/Node/Class.pm
@@ -39,6 +39,7 @@ methods in the class handle.
 # internal list of all the non-empty class objects, either defined by the
 # parser or created by plugins; does not include dummy base class objects
 my %all_classes;
+my $EnableRenamedTypes;
 
 sub init {
   my $this = shift;
@@ -219,5 +220,10 @@ the C++ and Perl name of the class are available as attributes.
 sub methods { $_[0]->{METHODS} }
 sub base_classes { $_[0]->{BASE_CLASSES} }
 sub empty { !$_[0]->methods || !@{$_[0]->methods} }
+sub xs_class_name { $EnableRenamedTypes ? $_[0]->perl_name : $_[0]->cpp_name }
+
+sub _enable_renamed_types_typemaps {
+  $EnableRenamedTypes = 1;
+}
 
 1;

--- a/lib/ExtUtils/XSpp/Node/Constructor.pm
+++ b/lib/ExtUtils/XSpp/Node/Constructor.pm
@@ -70,15 +70,14 @@ sub ret_type {
 
 sub perl_function_name {
   my $this = shift;
-  my( $pname, $cname, $pclass, $cclass ) = ( $this->perl_name,
-                                             $this->cpp_name,
-                                             $this->class->perl_name,
-                                             $this->class->cpp_name );
+  my( $pname, $cname, $class ) = ( $this->perl_name,
+                                   $this->cpp_name,
+                                   $this->class->xs_class_name );
 
   if( $pname ne $cname ) {
-    return $cclass . '::' . $pname;
+    return $class . '::' . $pname;
   } else {
-    return $cclass . '::' . 'new';
+    return $class . '::' . 'new';
   }
 }
 

--- a/lib/ExtUtils/XSpp/Node/Destructor.pm
+++ b/lib/ExtUtils/XSpp/Node/Destructor.pm
@@ -48,9 +48,9 @@ sub perl_function_name {
   my $this = shift;
 
   if( $this->perl_name ne $this->cpp_name ) {
-    return $this->class->cpp_name . '::' . $this->perl_name;
+    return $this->class->xs_class_name . '::' . $this->perl_name;
   } else {
-    return $this->class->cpp_name . '::' . 'DESTROY';
+    return $this->class->xs_class_name . '::' . 'DESTROY';
   }
 }
 

--- a/lib/ExtUtils/XSpp/Node/Function.pm
+++ b/lib/ExtUtils/XSpp/Node/Function.pm
@@ -57,6 +57,11 @@ sub init {
   $this->{TAGS}      = $args{tags};
   $this->{EMIT_CONDITION} = $args{emit_condition};
 
+  if ( @{$this->{ARGUMENTS}} && $this->{ARGUMENTS}[0]->name eq 'aTHX' ) {
+    $this->{THX} = 1;
+    shift @{$this->{ARGUMENTS}};
+  }
+
   my $index = 0;
   foreach my $arg ( @{$this->{ARGUMENTS}} ) {
       $arg->{FUNCTION} = $this;
@@ -232,6 +237,9 @@ sub print {
 
     $arg_list = ' ' . join( ', ', @arg_list ) . ' ';
     $call_arg_list = ' ' . join( ', ', @call_arg_list ) . ' ';
+  }
+  if ( $this->{THX} ) {
+    $call_arg_list = ( $args && @$args ? ' aTHX_' : ' aTHX ') . $call_arg_list;
   }
 
   # If there's %alias{foo = 123} definitions, generate ALIAS section

--- a/lib/ExtUtils/XSpp/Node/Function.pm
+++ b/lib/ExtUtils/XSpp/Node/Function.pm
@@ -174,12 +174,10 @@ sub add_exception_handlers {
   return();
 }
 
-# Depending on argument style, this produces either: (style=kr)
+# This produces an ANSI-style XS function:
 #
 # return_type
-# class_name::function_name( args = def, ... )
-#     type arg
-#     type arg
+# class_name::function_name( type arg1 = def, type arg2 = def, ... )
 #   PREINIT:
 #     aux vars
 #   [ALIAS:
@@ -192,13 +190,6 @@ sub add_exception_handlers {
 #     RETVAL
 #   CLEANUP:
 #     /* anything */
-#
-# Or: (style=ansi)
-#
-# return_type
-# class_name::function_name( type arg1 = def, type arg2 = def, ... )
-#   PREINIT:
-# (rest as above)
 
 sub print {
   my $this               = shift;

--- a/lib/ExtUtils/XSpp/Node/Function.pm
+++ b/lib/ExtUtils/XSpp/Node/Function.pm
@@ -96,6 +96,10 @@ sub resolve_typemaps {
     $this->{TYPEMAPS}{RET_TYPE} ||=
       ExtUtils::XSpp::Typemap::get_typemap_for_type( $this->ret_type );
   }
+  if( $this->is_method ) {
+    $this->{TYPEMAPS}{SELF} ||=
+      ExtUtils::XSpp::Typemap::get_typemap_for_type( $this->class->type );
+  }
   foreach my $a ( @{$this->arguments} ) {
     $this->{TYPEMAPS}{ARGUMENTS}[$index++] ||=
       ExtUtils::XSpp::Typemap::get_typemap_for_type( $a->type );
@@ -241,6 +245,7 @@ sub print {
   if ( $this->{THX} ) {
     $call_arg_list = ( $args && @$args ? ' aTHX_' : ' aTHX ') . $call_arg_list;
   }
+  _add_typedef( \%typedefs, $this->self_typemap ) if $this->is_method;
 
   # If there's %alias{foo = 123} definitions, generate ALIAS section
   if ($has_aliases) {

--- a/lib/ExtUtils/XSpp/Node/Function.pm
+++ b/lib/ExtUtils/XSpp/Node/Function.pm
@@ -281,7 +281,7 @@ sub print {
     $ccode = $this->_generate_alias_conditionals($call_arg_list, 0); # 0 == no RETVAL
   }
 
-  my @catchers = @{$this->{EXCEPTIONS}};
+  my @catchers = $state->{exceptions} ? @{$this->{EXCEPTIONS}} : ();
   $code .= "  $code_type:\n";
   $code .= "    try {\n" if @catchers;
   if ($precall) {

--- a/lib/ExtUtils/XSpp/Node/Method.pm
+++ b/lib/ExtUtils/XSpp/Node/Method.pm
@@ -58,7 +58,7 @@ sub perl_function_name {
     if( $self->package_static ) {
         return $self->perl_name;
     } else {
-        return $self->class->cpp_name . '::' . $self->perl_name;
+        return $self->class->xs_class_name . '::' . $self->perl_name;
     }
 }
 

--- a/lib/ExtUtils/XSpp/Node/Method.pm
+++ b/lib/ExtUtils/XSpp/Node/Method.pm
@@ -121,5 +121,6 @@ sub set_virtual { $_[0]->{VIRTUAL} = $_[1] }
 sub const { $_[0]->{CONST} }
 sub access { $_[0]->{ACCESS} }
 sub set_access { $_[0]->{ACCESS} = $_[1] }
+sub self_typemap { $_[0]->{TYPEMAPS}{SELF} }
 
 1;

--- a/lib/ExtUtils/XSpp/Plugin/feature/renamed_types_typemap.pm
+++ b/lib/ExtUtils/XSpp/Plugin/feature/renamed_types_typemap.pm
@@ -1,0 +1,13 @@
+package ExtUtils::XSpp::Plugin::feature::renamed_types_typemap;
+
+use strict;
+use warnings;
+
+sub register_plugin {
+    my( $class, $parser ) = @_;
+
+    ExtUtils::XSpp::Typemap::_enable_renamed_types_typemaps();
+    ExtUtils::XSpp::Node::Class::_enable_renamed_types_typemaps();
+}
+
+1;

--- a/lib/ExtUtils/XSpp/Typemap/parsed.pm
+++ b/lib/ExtUtils/XSpp/Typemap/parsed.pm
@@ -36,6 +36,8 @@ sub init {
 
 sub cpp_type { $_[0]->{CPP_TYPE} || $_[0]->{TYPE}->print }
 
+sub type_alias { }
+
 sub output_code {
   my( $this, $pvar, $cvar ) = @_;
   return unless defined $_[0]->{OUTPUT_CODE};

--- a/lib/ExtUtils/XSpp/Typemap/reference.pm
+++ b/lib/ExtUtils/XSpp/Typemap/reference.pm
@@ -15,6 +15,7 @@ sub init {
 
   $this->{XS_TYPE} = $args{xs_type};
   $this->{NAME} = $args{name};
+  $this->{ALIAS} = $args{alias};
   $this->{TYPE} = $args{type};
 }
 
@@ -22,6 +23,7 @@ sub cpp_type {
   my $type = $_[0]->type;
   $type->base_type . $type->print_tmpl_args . ('*' x ($type->is_pointer+1))
 }
+sub type_alias { @{$_[0]->{ALIAS} || []} }
 sub output_code { undef }
 sub call_parameter_code { "*( $_[1] )" }
 sub call_function_code {

--- a/lib/ExtUtils/XSpp/Typemap/simple.pm
+++ b/lib/ExtUtils/XSpp/Typemap/simple.pm
@@ -15,12 +15,14 @@ sub init {
 
   $this->{TYPE} = $args{type};
   $this->{NAME} = $args{name};
+  $this->{ALIAS} = $args{alias};
   $this->{XS_TYPE} = $args{xs_type};
   $this->{XS_INPUT_CODE} = $args{xs_input_code};
   $this->{XS_OUTPUT_CODE} = $args{xs_output_code};
 }
 
 sub cpp_type { $_[0]->{TYPE}->print }
+sub type_alias { @{$_[0]->{ALIAS} || []} }
 sub output_code { undef } # likewise
 sub call_parameter_code { undef }
 sub call_function_code { undef }

--- a/lib/ExtUtils/XSpp/Typemap/wrapper.pm
+++ b/lib/ExtUtils/XSpp/Typemap/wrapper.pm
@@ -11,6 +11,7 @@ sub init {
 
 sub type { shift->{TYPEMAP}->type( @_ ) }
 sub cpp_type { shift->{TYPEMAP}->cpp_type( @_ ) }
+sub type_alias { shift->{TYPEMAP}->type_alias( @_ ) }
 sub input_code { shift->{TYPEMAP}->input_code( @_ ) }
 sub precall_code { shift->{TYPEMAP}->precall_code( @_ ) }
 sub output_code { shift->{TYPEMAP}->output_code( @_ ) }

--- a/scripts/xspp
+++ b/scripts/xspp
@@ -21,6 +21,7 @@ xspp - XS++ preprocessor
 
     xspp [--typemap=typemap.xsp [--typemap=typemap2.xsp]]
          [--xsubpp[=/path/to/xsubpp] [--xsubpp-args="xsubpp args"]
+         [--no-exceptions]
          Foo.xsp
 
 or

--- a/t/001_load.t
+++ b/t/001_load.t
@@ -1,7 +1,5 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
 use Test::More tests => 1;
 
 use_ok( 'ExtUtils::XSpp' );

--- a/t/005_io.t
+++ b/t/005_io.t
@@ -14,6 +14,7 @@ unlink $_ foreach 't/files/foo.h';
 my $driver = ExtUtils::XSpp::Driver->new
   ( typemaps   => [ 't/files/typemap.xsp' ],
     file       => 't/files/test1.xsp',
+    exceptions => 1,
     );
 
 open my $fh, '>', \my $out;

--- a/t/010_base.t
+++ b/t/010_base.t
@@ -435,6 +435,7 @@ class Foo
 MODULE=XspTest
 TYPEMAP: <<END
 TYPEMAP
+const Foo*	O_OBJECT
 Foo*	O_OBJECT
 
 END

--- a/t/010_base.t
+++ b/t/010_base.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Basic class
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -18,9 +18,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a, int b, int c )
@@ -35,6 +35,16 @@ Foo::foo( int a, int b, int c )
       croak("Caught C++ exception of unknown type");
     }
   OUTPUT: RETVAL
+--- typemap
+Foo *   T_PTRREF
+--- preamble
+struct Foo {
+    int foo( int a, int b, int c ) { return a + b + c; }
+};
+--- test_code
+my $foo = \( my $bar = 1 );
+bless $foo, 'Foo';
+eq_or_diff( $foo->foo( 3, 4, 5 ), 12 );
 
 === Empty class
 --- xsp_stdout

--- a/t/010_base.t
+++ b/t/010_base.t
@@ -25,15 +25,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a, int b, int c )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b, c );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b, c );
   OUTPUT: RETVAL
 --- typemap
 Foo *   T_PTRREF
@@ -78,15 +70,7 @@ MODULE=XspTest PACKAGE=Foo::Bar
 int
 foo( int a )
   CODE:
-    try {
-      RETVAL = foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( a );
   OUTPUT: RETVAL
 --- preamble
 int foo( int a ) { return a + 1; }
@@ -112,15 +96,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a = 1, int b = 0x1, int c = 1 | 2 )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b, c );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b, c );
   OUTPUT: RETVAL
 --- typemap
 Foo *   T_PTRREF
@@ -158,15 +134,7 @@ MODULE=XspTest PACKAGE=Foo
 Foo*
 Foo::new( int a = 1 )
   CODE:
-    try {
-      RETVAL = new Foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = new Foo( a );
   OUTPUT: RETVAL
 
 #undef  xsp_constructor_class
@@ -197,15 +165,7 @@ MODULE=XspTest PACKAGE=Foo
 void
 Foo::DESTROY()
   CODE:
-    try {
-      delete THIS;
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    delete THIS;
 --- typemap
 Foo *   T_PTRREF
 --- preamble
@@ -231,15 +191,7 @@ MODULE=XspTest PACKAGE=Foo
 void
 Foo::foo( int a )
   CODE:
-    try {
-      THIS->foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->foo( a );
 
 === No parameters
 --- xsp_stdout
@@ -261,28 +213,12 @@ MODULE=XspTest PACKAGE=Foo
 void
 Foo::foo()
   CODE:
-    try {
-      THIS->foo();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->foo();
 
 void
 Foo::bar()
   CODE:
-    try {
-      THIS->bar();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->bar();
 
 === Comments and raw blocks
 --- xsp_stdout
@@ -346,15 +282,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a, int b, int c )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b, c );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b, c );
   OUTPUT: RETVAL
 
 # after method
@@ -378,15 +306,7 @@ MODULE=XspTest PACKAGE=Bar
 unsigned int
 bar( char* line, unsigned long length(line) )
   CODE:
-    try {
-      RETVAL = bar( line, XSauto_length_of_line );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = bar( line, XSauto_length_of_line );
   OUTPUT: RETVAL
 
 === %length and %code
@@ -433,15 +353,7 @@ MODULE=XspTest PACKAGE=Bar
 unsigned int
 bar( char* line, unsigned long length(line) )
   CODE:
-    try {
-      RETVAL = bar( line, XSauto_length_of_line );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = bar( line, XSauto_length_of_line );
   POSTCALL:
      cout << XSauto_length_of_line << endl;
   OUTPUT: RETVAL
@@ -467,15 +379,7 @@ MODULE=XspTest PACKAGE=Bar
 short
 bar( short a, unsigned short b, unsigned int c, unsigned int d, int e, unsigned short f, long g, unsigned long h )
   CODE:
-    try {
-      RETVAL = bar( a, b, c, d, e, f, g, h );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = bar( a, b, c, d, e, f, g, h );
   OUTPUT: RETVAL
 
 === verbatim code blocks for xsubs

--- a/t/010_base.t
+++ b/t/010_base.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 14;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/010_base.t
+++ b/t/010_base.t
@@ -48,7 +48,7 @@ eq_or_diff( $foo->foo( 3, 4, 5 ), 12 );
 
 === Empty class
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -57,13 +57,13 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 === Basic function
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo::Bar};
 
 int foo( int a );
@@ -71,9 +71,9 @@ int foo( int a );
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo::Bar
+MODULE=XspTest PACKAGE=Foo::Bar
 
 int
 foo( int a )
@@ -91,7 +91,7 @@ foo( int a )
 
 === Default arguments
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -101,9 +101,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a = 1, int b = 0x1, int c = 1 | 2 )
@@ -121,7 +121,7 @@ Foo::foo( int a = 1, int b = 0x1, int c = 1 | 2 )
 
 === Constructor
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -131,9 +131,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 #undef  xsp_constructor_class
 #define xsp_constructor_class(c) (CLASS)
@@ -157,7 +157,7 @@ Foo::new( int a = 1 )
 
 === Destructor
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -167,9 +167,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::DESTROY()
@@ -186,7 +186,7 @@ Foo::DESTROY()
 
 === Void function
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -196,9 +196,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::foo( int a )
@@ -215,7 +215,7 @@ Foo::foo( int a )
 
 === No parameters
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -226,9 +226,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::foo()
@@ -261,7 +261,7 @@ Foo::bar()
 // comment before %module
 ## comment before %module
 
-%module{Foo};
+%module{XspTest};
 
 ## comment after %module
 // comment after %module
@@ -293,7 +293,7 @@ class Foo
 ## comment before %module
 
 
-MODULE=Foo
+MODULE=XspTest
 ## comment after %module
 
 
@@ -310,7 +310,7 @@ MODULE=Foo
 
 
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 ## before method
 
@@ -333,7 +333,7 @@ Foo::foo( int a, int b, int c )
 
 === %length and ANSI style
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %package{Bar};
 
@@ -343,9 +343,9 @@ bar( char* line, unsigned long %length{line} );
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Bar
+MODULE=XspTest PACKAGE=Bar
 
 unsigned int
 bar( char* line, unsigned long length(line) )
@@ -363,7 +363,7 @@ bar( char* line, unsigned long length(line) )
 
 === %length and %code
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %package{Bar};
 
@@ -374,9 +374,9 @@ bar( char* line, unsigned long %length{line} )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Bar
+MODULE=XspTest PACKAGE=Bar
 
 unsigned int
 bar( char* line, unsigned long length(line) )
@@ -386,7 +386,7 @@ bar( char* line, unsigned long length(line) )
 
 === %length and %postcall, %cleanup
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %package{Bar};
 
@@ -398,9 +398,9 @@ bar( char* line, unsigned long %length{line} )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Bar
+MODULE=XspTest PACKAGE=Bar
 
 unsigned int
 bar( char* line, unsigned long length(line) )
@@ -422,7 +422,7 @@ bar( char* line, unsigned long length(line) )
 
 === various integer types
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %package{Bar};
 
@@ -432,9 +432,9 @@ bar( short a, unsigned short int b, unsigned c, unsigned int d, int e, unsigned 
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Bar
+MODULE=XspTest PACKAGE=Bar
 
 short
 bar( short a, unsigned short b, unsigned int c, unsigned int d, int e, unsigned short f, long g, unsigned long h )

--- a/t/010_base.t
+++ b/t/010_base.t
@@ -44,7 +44,7 @@ struct Foo {
 --- test_code
 my $foo = \( my $bar = 1 );
 bless $foo, 'Foo';
-eq_or_diff( $foo->foo( 3, 4, 5 ), 12 );
+is( $foo->foo( 3, 4, 5 ), 12 );
 
 === Empty class
 --- xsp_stdout
@@ -88,6 +88,10 @@ foo( int a )
       croak("Caught C++ exception of unknown type");
     }
   OUTPUT: RETVAL
+--- preamble
+int foo( int a ) { return a + 1; }
+--- test_code
+is( Foo::Bar::foo( 3 ), 4 );
 
 === Default arguments
 --- xsp_stdout
@@ -118,6 +122,19 @@ Foo::foo( int a = 1, int b = 0x1, int c = 1 | 2 )
       croak("Caught C++ exception of unknown type");
     }
   OUTPUT: RETVAL
+--- typemap
+Foo *   T_PTRREF
+--- preamble
+struct Foo {
+    int foo( int a, int b, int c ) { return a + b + c; }
+};
+--- test_code
+my $foo = \( my $bar = 1 );
+bless $foo, 'Foo';
+is( $foo->foo, 5 );
+is( $foo->foo( 7 ), 11 );
+is( $foo->foo( 7, 8 ), 18 );
+is( $foo->foo( 7, 8, 9 ), 24 );
 
 === Constructor
 --- xsp_stdout
@@ -154,6 +171,12 @@ Foo::new( int a = 1 )
 
 #undef  xsp_constructor_class
 #define xsp_constructor_class(c) (c)
+--- typemap
+Foo *   T_PTRREF
+--- preamble
+struct Foo {
+    Foo( int a ) { }
+};
 
 === Destructor
 --- xsp_stdout
@@ -183,6 +206,11 @@ Foo::DESTROY()
     catch (...) {
       croak("Caught C++ exception of unknown type");
     }
+--- typemap
+Foo *   T_PTRREF
+--- preamble
+struct Foo {
+};
 
 === Void function
 --- xsp_stdout
@@ -449,6 +477,7 @@ bar( short a, unsigned short b, unsigned int c, unsigned int d, int e, unsigned 
       croak("Caught C++ exception of unknown type");
     }
   OUTPUT: RETVAL
+
 === verbatim code blocks for xsubs
 --- xsp_stdout
 %module{Wx};

--- a/t/011_multiple_files.t
+++ b/t/011_multiple_files.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 3;
+use t::lib::XSP::Test;
 
 run_diff process => 'expected';
 

--- a/t/011_multiple_files.t
+++ b/t/011_multiple_files.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Basic file - stdout
 --- process xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %file{foo.h};
@@ -23,9 +23,9 @@ int foo( int a, int b, int c );
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 foo( int a, int b, int c )
@@ -43,7 +43,7 @@ foo( int a, int b, int c )
 
 === Basic file - external file
 --- process xsp_file=foo.h
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %file{foo.h};
@@ -64,7 +64,7 @@ text
 
 === Basic file - processed external file
 --- process xsp_file=foo.h
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %file{foo.h};

--- a/t/011_multiple_files.t
+++ b/t/011_multiple_files.t
@@ -30,15 +30,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 foo( int a, int b, int c )
   CODE:
-    try {
-      RETVAL = foo( a, b, c );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( a, b, c );
   OUTPUT: RETVAL
 
 === Basic file - external file
@@ -79,13 +71,5 @@ int foo( int a, int b, int c );
 int
 bar( int x )
   CODE:
-    try {
-      RETVAL = bar( x );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = bar( x );
   OUTPUT: RETVAL

--- a/t/012_preprocessor.t
+++ b/t/012_preprocessor.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 6;
+use t::lib::XSP::Test;
 
 # monkeypatch print methods to test conditionals are parsed correctly
 no warnings 'redefine';

--- a/t/012_preprocessor.t
+++ b/t/012_preprocessor.t
@@ -127,7 +127,7 @@ __DATA__
 
 === functions
 --- process xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 #if ONE
 
@@ -141,7 +141,7 @@ int bar();
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 #if ONE
 #define XSpp_zzzzzzzz_017082
 
@@ -156,7 +156,7 @@ MODULE=Foo
 
 === enums
 --- process xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 #if ONE
 
@@ -173,7 +173,7 @@ enum Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 #if ONE
 #define XSpp_zzzzzzzz_017082
 
@@ -189,7 +189,7 @@ enum Foo XSpp_zzzzzzzz_017082
 
 === classes/methods
 --- process xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 #if ONE
 
@@ -206,7 +206,7 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 #if ONE
 #define XSpp_zzzzzzzz_017082
 

--- a/t/013_typemap_output.t
+++ b/t/013_typemap_output.t
@@ -51,6 +51,11 @@ class bar
 HERE
 
 eq_or_diff($d->generate->{'-'}, <<'HERE');
+#undef  xsp_constructor_class
+#define xsp_constructor_class(c) (c)
+
+
+MODULE=Foo2
 TYPEMAP: <<END
 TYPEMAP
 bar*	T_BAR
@@ -64,11 +69,6 @@ T_BAR
 	MY_OUT($arg, $var, Bar)
 
 END
-#undef  xsp_constructor_class
-#define xsp_constructor_class(c) (c)
-
-
-MODULE=Foo2
 
 MODULE=Foo2 PACKAGE=bar
 
@@ -100,17 +100,16 @@ class Foo
     int foo( int a, int b, int c );
 };
 --- expected
+# XSP preamble
+
+
+MODULE=Foo
 TYPEMAP: <<END
 TYPEMAP
 Foo*	O_OBJECT
 bar*	T_BAR
 
 END
-# XSP preamble
-
-
-MODULE=Foo
-
 MODULE=Foo PACKAGE=Foo
 
 int
@@ -135,16 +134,15 @@ class Foo
     int foo( int a, int b, int c );
 };
 --- expected
+# XSP preamble
+
+
+MODULE=Foo
 TYPEMAP: <<END
 TYPEMAP
 Foo*	T_BAR
 
 END
-# XSP preamble
-
-
-MODULE=Foo
-
 MODULE=Foo PACKAGE=Foo
 
 int

--- a/t/013_typemap_output.t
+++ b/t/013_typemap_output.t
@@ -41,7 +41,7 @@ EXPECTED
 
 # Now check whether adding a class may overwrite existing typemaps.
 # Process class of same name as manual typemap
-my $d = ExtUtils::XSpp::Driver->new( string => <<'HERE', exceptions => 1 );
+my $d = ExtUtils::XSpp::Driver->new( string => <<'HERE', exceptions => 0 );
 %module{Foo2};
 
 class bar
@@ -64,7 +64,6 @@ T_BAR
 	MY_OUT($arg, $var, Bar)
 
 END
-#include <exception>
 #undef  xsp_constructor_class
 #define xsp_constructor_class(c) (c)
 
@@ -76,15 +75,7 @@ MODULE=Foo2 PACKAGE=bar
 int
 bar::foo2( int a, int b, int c )
   CODE:
-    try {
-      RETVAL = THIS->foo2( a, b, c );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo2( a, b, c );
   OUTPUT: RETVAL
 
 HERE
@@ -125,15 +116,7 @@ MODULE=Foo PACKAGE=Foo
 int
 Foo::foo( int a, int b, int c )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b, c );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b, c );
   OUTPUT: RETVAL
 
 === Override default
@@ -167,13 +150,5 @@ MODULE=Foo PACKAGE=Foo
 int
 Foo::foo( int a, int b, int c )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b, c );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b, c );
   OUTPUT: RETVAL

--- a/t/013_typemap_output.t
+++ b/t/013_typemap_output.t
@@ -106,6 +106,7 @@ class Foo
 MODULE=Foo
 TYPEMAP: <<END
 TYPEMAP
+const Foo*	O_OBJECT
 Foo*	O_OBJECT
 bar*	T_BAR
 
@@ -140,6 +141,7 @@ class Foo
 MODULE=Foo
 TYPEMAP: <<END
 TYPEMAP
+const Foo*	T_BAR
 Foo*	T_BAR
 
 END

--- a/t/013_typemap_output.t
+++ b/t/013_typemap_output.t
@@ -43,7 +43,7 @@ EXPECTED
 
 # Now check whether adding a class may overwrite existing typemaps.
 # Process class of same name as manual typemap
-my $d = ExtUtils::XSpp::Driver->new( string => <<'HERE' );
+my $d = ExtUtils::XSpp::Driver->new( string => <<'HERE', exceptions => 1 );
 %module{Foo2};
 
 class bar

--- a/t/013_typemap_output.t
+++ b/t/013_typemap_output.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 5;
+use t::lib::XSP::Test;
 
 use ExtUtils::XSpp;
 use ExtUtils::XSpp::Typemap::simple;

--- a/t/015_reference.t
+++ b/t/015_reference.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 2;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/015_reference.t
+++ b/t/015_reference.t
@@ -25,15 +25,7 @@ MODULE=XspTest PACKAGE=Foo
 void
 Foo::foo( Foo* a )
   CODE:
-    try {
-      THIS->foo( *( a ) );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->foo( *( a ) );
 
 === Reference in return value
 --- xsp_stdout
@@ -54,14 +46,6 @@ MODULE=XspTest PACKAGE=Foo
 Foo*
 Foo::foo()
   CODE:
-    try {
-      RETVAL = new Foo( THIS->foo() );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = new Foo( THIS->foo() );
   OUTPUT: RETVAL
 

--- a/t/015_reference.t
+++ b/t/015_reference.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Reference in argument
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -18,9 +18,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::foo( Foo* a )
@@ -37,7 +37,7 @@ Foo::foo( Foo* a )
 
 === Reference in return value
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -47,9 +47,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 Foo*
 Foo::foo()

--- a/t/020_rename.t
+++ b/t/020_rename.t
@@ -279,6 +279,7 @@ Foo::bar()
 MODULE=XspTest
 TYPEMAP: <<END
 TYPEMAP
+const Bar::Baz*	O_OBJECT
 Bar::Baz*	O_OBJECT
 
 END

--- a/t/020_rename.t
+++ b/t/020_rename.t
@@ -10,7 +10,7 @@ __DATA__
 
 === Renamed function (also in different package)
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo::Bar};
 
 %name{boo} int foo(int a);
@@ -19,9 +19,9 @@ __DATA__
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo::Bar
+MODULE=XspTest PACKAGE=Foo::Bar
 
 int
 boo( int a )
@@ -37,7 +37,7 @@ boo( int a )
     }
   OUTPUT: RETVAL
 
-MODULE=Foo PACKAGE=moo
+MODULE=XspTest PACKAGE=moo
 
 int
 boo( int a )
@@ -55,7 +55,7 @@ boo( int a )
 
 === Function with alias
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo::Bar};
 
 %name{boo} int foo2(int a) %alias{baz2 = 3};
@@ -63,9 +63,9 @@ boo( int a )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo::Bar
+MODULE=XspTest PACKAGE=Foo::Bar
 
 int
 boo( int a )
@@ -92,7 +92,7 @@ boo( int a )
 
 === Function with alias and code
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo::Bar};
 
 %name{boo} int foo2(int a) %alias{baz2 = 3} %code{%RETVAL = a;%};
@@ -100,9 +100,9 @@ boo( int a )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo::Bar
+MODULE=XspTest PACKAGE=Foo::Bar
 
 int
 boo( int a )
@@ -114,7 +114,7 @@ boo( int a )
 
 === Function with multiple aliases
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo::Bar};
 
 %name{boo} int foo2(int a) %alias{baz2 = 3} %alias{buz2 = 1};
@@ -122,9 +122,9 @@ boo( int a )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo::Bar
+MODULE=XspTest PACKAGE=Foo::Bar
 
 int
 boo( int a )
@@ -155,7 +155,7 @@ boo( int a )
 
 === Renamed method
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -165,9 +165,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::bar( int a )
@@ -185,7 +185,7 @@ Foo::bar( int a )
 
 === Renamed method with alias
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -195,9 +195,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::bar( int a )
@@ -224,7 +224,7 @@ Foo::bar( int a )
 
 === Renamed constructor
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -234,9 +234,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 #undef  xsp_constructor_class
 #define xsp_constructor_class(c) (CLASS)
@@ -260,7 +260,7 @@ Foo::newFoo( int a )
 
 === Renamed destructor
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -270,9 +270,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::destroy()
@@ -289,7 +289,7 @@ Foo::destroy()
 
 === Renamed class
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %name{Bar::Baz} class Foo
 {
@@ -300,9 +300,9 @@ Foo::destroy()
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Bar::Baz
+MODULE=XspTest PACKAGE=Bar::Baz
 
 void
 Foo::foo()

--- a/t/020_rename.t
+++ b/t/020_rename.t
@@ -270,6 +270,7 @@ Foo::bar()
     Foo(int v);
     Foo *inc();
     int add(Foo *other);
+    int add_int(int other);
 };
 --- expected
 # XSP preamble
@@ -310,12 +311,21 @@ Bar::Baz::add( Bar::Baz* other )
   CODE:
     RETVAL = THIS->add( other );
   OUTPUT: RETVAL
+
+int
+Bar::Baz::add_int( int other )
+  PREINIT:
+    typedef Foo Bar__Baz;
+  CODE:
+    RETVAL = THIS->add_int( other );
+  OUTPUT: RETVAL
 --- preamble
 struct Foo {
     Foo(int v) : value(v) { }
 
     Foo *inc() { value++; return this; }
     int add(Foo *other) { return value + other->value; }
+    int add_int(int other) { return value + other; }
 
     int value;
 };

--- a/t/020_rename.t
+++ b/t/020_rename.t
@@ -26,15 +26,7 @@ MODULE=XspTest PACKAGE=Foo::Bar
 int
 boo( int a )
   CODE:
-    try {
-      RETVAL = foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( a );
   OUTPUT: RETVAL
 
 MODULE=XspTest PACKAGE=moo
@@ -42,15 +34,7 @@ MODULE=XspTest PACKAGE=moo
 int
 boo( int a )
   CODE:
-    try {
-      RETVAL = foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( a );
   OUTPUT: RETVAL
 
 === Function with alias
@@ -72,8 +56,7 @@ boo( int a )
   ALIAS:
     baz2 = 3
   CODE:
-    try {
-      if (ix == 0) {
+    if (ix == 0) {
         RETVAL = foo2( a );
       }
       else if (ix == 3) {
@@ -81,13 +64,6 @@ boo( int a )
       }
       else
         croak("Panic: Invalid invocation of function alias number %i!", (int)ix));
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
   OUTPUT: RETVAL
 
 === Function with alias and code
@@ -132,8 +108,7 @@ boo( int a )
     buz2 = 1
     baz2 = 3
   CODE:
-    try {
-      if (ix == 0) {
+    if (ix == 0) {
         RETVAL = foo2( a );
       }
       else if (ix == 1) {
@@ -144,13 +119,6 @@ boo( int a )
       }
       else
         croak("Panic: Invalid invocation of function alias number %i!", (int)ix));
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
   OUTPUT: RETVAL
 
 === Renamed method
@@ -172,15 +140,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::bar( int a )
   CODE:
-    try {
-      RETVAL = THIS->foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a );
   OUTPUT: RETVAL
 
 === Renamed method with alias
@@ -204,8 +164,7 @@ Foo::bar( int a )
   ALIAS:
     baz = 1
   CODE:
-    try {
-      if (ix == 0) {
+    if (ix == 0) {
         RETVAL = THIS->foo( a );
       }
       else if (ix == 1) {
@@ -213,13 +172,6 @@ Foo::bar( int a )
       }
       else
         croak("Panic: Invalid invocation of function alias number %i!", (int)ix));
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
   OUTPUT: RETVAL
 
 === Renamed constructor
@@ -244,15 +196,7 @@ MODULE=XspTest PACKAGE=Foo
 static Foo*
 Foo::newFoo( int a )
   CODE:
-    try {
-      RETVAL = new Foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = new Foo( a );
   OUTPUT: RETVAL
 
 #undef  xsp_constructor_class
@@ -277,15 +221,7 @@ MODULE=XspTest PACKAGE=Foo
 void
 Foo::destroy()
   CODE:
-    try {
-      delete THIS;
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    delete THIS;
 
 === Renamed class
 --- xsp_stdout
@@ -307,26 +243,10 @@ MODULE=XspTest PACKAGE=Bar::Baz
 void
 Foo::foo()
   CODE:
-    try {
-      THIS->foo();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->foo();
 
 int
 Foo::foo_int( int a )
   CODE:
-    try {
-      RETVAL = THIS->foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a );
   OUTPUT: RETVAL

--- a/t/020_rename.t
+++ b/t/020_rename.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 9;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/022_static.t
+++ b/t/022_static.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 1;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/022_static.t
+++ b/t/022_static.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Method decorated with package_static
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -18,9 +18,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 foo( int a )

--- a/t/022_static.t
+++ b/t/022_static.t
@@ -25,13 +25,5 @@ MODULE=XspTest PACKAGE=Foo
 int
 foo( int a )
   CODE:
-    try {
-      RETVAL = Foo::foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = Foo::foo( a );
   OUTPUT: RETVAL

--- a/t/022_virtual.t
+++ b/t/022_virtual.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 3;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/022_virtual.t
+++ b/t/022_virtual.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Virtual method
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -21,9 +21,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a )
@@ -39,7 +39,7 @@ Foo::bar( int a )
 
 === Virtual destructor
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -50,9 +50,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::DESTROY()
@@ -61,7 +61,7 @@ Foo::DESTROY()
 
 === Pure-virtual method
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -74,9 +74,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a )

--- a/t/023_base_classes.t
+++ b/t/023_base_classes.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 2;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/023_base_classes.t
+++ b/t/023_base_classes.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Classes with base classes
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo : public Moo
 {
@@ -18,9 +18,9 @@ class Foo : public Moo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::foo()
@@ -43,7 +43,7 @@ BOOT:
 
 === Classes with renamed base classes
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo : public %name{PlMoo} Moo, public Boo
 {
@@ -53,9 +53,9 @@ class Foo : public %name{PlMoo} Moo, public Boo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 Foo::foo()

--- a/t/023_base_classes.t
+++ b/t/023_base_classes.t
@@ -25,15 +25,7 @@ MODULE=XspTest PACKAGE=Foo
 void
 Foo::foo()
   CODE:
-    try {
-      THIS->foo();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->foo();
 
 BOOT:
     {
@@ -60,15 +52,7 @@ MODULE=XspTest PACKAGE=Foo
 void
 Foo::foo()
   CODE:
-    try {
-      THIS->foo();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->foo();
 
 BOOT:
     {

--- a/t/024_enum.t
+++ b/t/024_enum.t
@@ -20,7 +20,7 @@ __DATA__
 
 === Parse and ignore named enums
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 enum Values
 {
@@ -32,7 +32,7 @@ enum Values
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 // Values
 //     ONE
 //     TWO
@@ -40,7 +40,7 @@ MODULE=Foo
 
 === Parse and ignore anonymout enums
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 enum
 {
@@ -52,7 +52,7 @@ enum
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 // <anonymous>
 //     ONE
 //     TWO

--- a/t/024_enum.t
+++ b/t/024_enum.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 2;
+use t::lib::XSP::Test;
 
 # monkeypatch Enum/EnumValue just to test that they were parsed correctly
 no warnings 'redefine';

--- a/t/025_member.t
+++ b/t/025_member.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 4;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/025_member.t
+++ b/t/025_member.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Basic accessors
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -18,9 +18,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::get_foo()
@@ -36,7 +36,7 @@ Foo::set_foo( int value )
 
 === Only getter/setter
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -47,9 +47,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::get_foo()
@@ -65,7 +65,7 @@ Foo::set_bar( int value )
 
 === Getter/setter name
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo
 {
@@ -75,9 +75,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::readFoo()
@@ -93,7 +93,7 @@ Foo::writeFoo( int value )
 
 === Getter/setter style
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class Foo1
 {
@@ -158,9 +158,9 @@ class Foo6
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo1
+MODULE=XspTest PACKAGE=Foo1
 
 int
 Foo1::get_bar()
@@ -174,7 +174,7 @@ Foo1::set_bar( int value )
     THIS->foo = value;
 
 
-MODULE=Foo PACKAGE=Foo2
+MODULE=XspTest PACKAGE=Foo2
 
 int
 Foo2::bar()
@@ -188,7 +188,7 @@ Foo2::setBar( int value )
     THIS->foo = value;
 
 
-MODULE=Foo PACKAGE=Foo3
+MODULE=XspTest PACKAGE=Foo3
 
 int
 Foo3::bar()
@@ -202,7 +202,7 @@ Foo3::set_bar( int value )
     THIS->foo = value;
 
 
-MODULE=Foo PACKAGE=Foo4
+MODULE=XspTest PACKAGE=Foo4
 
 int
 Foo4::GetBar()
@@ -216,7 +216,7 @@ Foo4::SetBar( int value )
     THIS->foo = value;
 
 
-MODULE=Foo PACKAGE=Foo5
+MODULE=XspTest PACKAGE=Foo5
 
 int
 Foo5::bar()
@@ -230,7 +230,7 @@ Foo5::SetBar( int value )
     THIS->foo = value;
 
 
-MODULE=Foo PACKAGE=Foo6
+MODULE=XspTest PACKAGE=Foo6
 
 int
 Foo6::getBar()

--- a/t/026_thx.t
+++ b/t/026_thx.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl -w
+
+use t::lib::XSP::Test;
+
+run_diff xsp_stdout => 'expected';
+
+__DATA__
+
+=== Functions/methods with aTHX/aTHX_ argument
+--- xsp_stdout
+%module{XspTest};
+
+class Foo
+{
+    int foo(aTHX_ int a);
+    int bar(aTHX);
+    int baz(aTHX, int a);
+};
+--- expected
+# XSP preamble
+
+
+MODULE=XspTest
+
+MODULE=XspTest PACKAGE=Foo
+
+int
+Foo::foo( int a )
+  CODE:
+    RETVAL = THIS->foo( aTHX_ a );
+  OUTPUT: RETVAL
+
+int
+Foo::bar()
+  CODE:
+    RETVAL = THIS->bar( aTHX );
+  OUTPUT: RETVAL
+
+int
+Foo::baz( int a )
+  CODE:
+    RETVAL = THIS->baz( aTHX_ a );
+  OUTPUT: RETVAL
+--- typemap
+Foo *   T_PTRREF
+--- preamble
+struct Foo {
+    int foo(aTHX_ int a) { return a + 2; }
+    int bar(aTHX) { return 7; }
+    int baz(aTHX_ int a) { return a + 1; }
+};

--- a/t/030_code_blocks.t
+++ b/t/030_code_blocks.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 6;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/030_code_blocks.t
+++ b/t/030_code_blocks.t
@@ -45,15 +45,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 boo( int a )
   CODE:
-    try {
-      RETVAL = foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( a );
   OUTPUT: RETVAL
   CLEANUP:
      free( it ); 
@@ -76,15 +68,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 foo( int a )
   CODE:
-    try {
-      RETVAL = foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( a );
   POSTCALL:
      blub( a ); 
   OUTPUT: RETVAL
@@ -150,14 +134,6 @@ MODULE=XspTest PACKAGE=Foo
 void
 foo( int a )
   CODE:
-    try {
-      foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    foo( a );
   POSTCALL:
      blub( a ); 

--- a/t/030_code_blocks.t
+++ b/t/030_code_blocks.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Function with custom code block
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %name{boo} int foo(int a)
@@ -17,9 +17,9 @@ __DATA__
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 boo( int a )
@@ -29,7 +29,7 @@ boo( int a )
 
 === Function with custom cleanup block
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %name{boo} int foo(int a)
@@ -38,9 +38,9 @@ boo( int a )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 boo( int a )
@@ -60,7 +60,7 @@ boo( int a )
 
 === Function with custom postcall block
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 int foo(int a)
@@ -69,9 +69,9 @@ int foo(int a)
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 foo( int a )
@@ -91,7 +91,7 @@ foo( int a )
 
 === Void function with custom code block
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %name{boo} void foo(int a)
@@ -100,9 +100,9 @@ foo( int a )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 boo( int a )
@@ -111,7 +111,7 @@ boo( int a )
 
 === Void function with custom code and cleanup blocks
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %name{boo} void foo(int a)
@@ -121,9 +121,9 @@ boo( int a )
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 boo( int a )
@@ -134,7 +134,7 @@ boo( int a )
 
 === Void function with custom postcall block
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 void foo(int a)
@@ -143,9 +143,9 @@ void foo(int a)
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 foo( int a )

--- a/t/031_verbatim_blocks.t
+++ b/t/031_verbatim_blocks.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 2;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/031_verbatim_blocks.t
+++ b/t/031_verbatim_blocks.t
@@ -51,14 +51,6 @@ Straight to XS, no checks...
 int
 X::foo( int a )
   CODE:
-    try {
-      RETVAL = THIS->foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a );
   OUTPUT: RETVAL
 

--- a/t/031_verbatim_blocks.t
+++ b/t/031_verbatim_blocks.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Verbatim blocks
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %{
@@ -18,16 +18,16 @@ Straight to XS, no checks...
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 
 Straight to XS, no checks...
 
 === Space after verbatim blocks
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class X
 {
@@ -40,9 +40,9 @@ Straight to XS, no checks...
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=X
+MODULE=XspTest PACKAGE=X
 
 
 Straight to XS, no checks...

--- a/t/035_include.t
+++ b/t/035_include.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 1;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/035_include.t
+++ b/t/035_include.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Simple include files
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %include{t/files/typemap.xsp};
@@ -18,9 +18,9 @@ int bar(int y);
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 # trivial typemap
 

--- a/t/035_include.t
+++ b/t/035_include.t
@@ -28,27 +28,11 @@ MODULE=XspTest PACKAGE=Foo
 int
 foo( int x )
   CODE:
-    try {
-      RETVAL = foo( x );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( x );
   OUTPUT: RETVAL
 
 int
 bar( int y )
   CODE:
-    try {
-      RETVAL = bar( y );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = bar( y );
   OUTPUT: RETVAL

--- a/t/040_plugin.t
+++ b/t/040_plugin.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 2;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/040_plugin.t
+++ b/t/040_plugin.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Basic plugin functionality
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 %loadplugin{t::lib::XSP::Plugin};
 %loadplugin{t::lib::XSP::Plugin};
@@ -23,9 +23,9 @@ class Y
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 foo_perl( int y )
@@ -42,7 +42,7 @@ foo_perl( int y )
   OUTPUT: RETVAL
 
 
-MODULE=Foo PACKAGE=Y
+MODULE=XspTest PACKAGE=Y
 
 void
 Y::bar()
@@ -59,7 +59,7 @@ Y::bar()
 
 === Plugin loading from the plugin namespace
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 %loadplugin{TestPlugin};
 
@@ -73,9 +73,9 @@ class Y
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 foo_perl2( int y )
@@ -92,7 +92,7 @@ foo_perl2( int y )
   OUTPUT: RETVAL
 
 
-MODULE=Foo PACKAGE=Y
+MODULE=XspTest PACKAGE=Y
 
 void
 Y::bar()

--- a/t/040_plugin.t
+++ b/t/040_plugin.t
@@ -30,15 +30,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 foo_perl( int y )
   CODE:
-    try {
-      RETVAL = foo( y );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( y );
   OUTPUT: RETVAL
 
 
@@ -47,15 +39,7 @@ MODULE=XspTest PACKAGE=Y
 void
 Y::bar()
   CODE:
-    try {
-      THIS->bar();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->bar();
 
 === Plugin loading from the plugin namespace
 --- xsp_stdout
@@ -80,15 +64,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 foo_perl2( int y )
   CODE:
-    try {
-      RETVAL = foo( y );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( y );
   OUTPUT: RETVAL
 
 
@@ -97,12 +73,4 @@ MODULE=XspTest PACKAGE=Y
 void
 Y::bar()
   CODE:
-    try {
-      THIS->bar();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->bar();

--- a/t/043_parser_plugins.t
+++ b/t/043_parser_plugins.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 4;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/043_parser_plugins.t
+++ b/t/043_parser_plugins.t
@@ -35,15 +35,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo( int y )
   CODE:
-    try {
-      RETVAL = foo( y );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo( y );
   OUTPUT: RETVAL
 
 // function foo
@@ -58,15 +50,7 @@ MODULE=XspTest PACKAGE=Klass
 static klass*
 klass::newKlass()
   CODE:
-    try {
-      RETVAL = new klass();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = new klass();
   OUTPUT: RETVAL
 
 #undef  xsp_constructor_class
@@ -75,15 +59,7 @@ klass::newKlass()
 void
 klass::Bar()
   CODE:
-    try {
-      THIS->bar();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    THIS->bar();
 
 // method klass::klass
 
@@ -137,16 +113,8 @@ MODULE=XspTest PACKAGE=klass
 int
 klass::bar( int bar, int foo )
   CODE:
-    try {
       // wrapped typemap 1;
-      RETVAL = THIS->bar( bar, foo );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->bar( bar, foo );
   OUTPUT: RETVAL
   CLEANUP:
     // wrapped typemap ret;

--- a/t/043_parser_plugins.t
+++ b/t/043_parser_plugins.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Handle class/method/function annotations
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 %loadplugin{TestParserPlugin};
 %loadplugin{TestNewNodesPlugin};
@@ -28,9 +28,9 @@ class klass
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo( int y )
@@ -50,7 +50,7 @@ Foo( int y )
 
 
 
-MODULE=Foo PACKAGE=Klass
+MODULE=XspTest PACKAGE=Klass
 
 #undef  xsp_constructor_class
 #define xsp_constructor_class(c) (CLASS)
@@ -95,7 +95,7 @@ klass::Bar()
 
 === Handle top level directives
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 %loadplugin{TestParserPlugin};
 %loadplugin{TestNewNodesPlugin};
@@ -107,9 +107,9 @@ klass::Bar()
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 // directive MyComment
 
@@ -118,7 +118,7 @@ MODULE=Foo PACKAGE=Foo
 
 === Handle argument annotations
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %loadplugin{TestArgumentPlugin};
 
@@ -130,9 +130,9 @@ class klass
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=klass
+MODULE=XspTest PACKAGE=klass
 
 int
 klass::bar( int bar, int foo )
@@ -153,7 +153,7 @@ klass::bar( int bar, int foo )
 
 === Handle member annotations
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 class klass
 {
@@ -164,6 +164,6 @@ class klass
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=klass
+MODULE=XspTest PACKAGE=klass

--- a/t/075_types.t
+++ b/t/075_types.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Pointer/const pointer type
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %typemap{int*}{simple};
@@ -20,9 +20,9 @@ int* boo(const int* a);
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int*
 foo()
@@ -54,7 +54,7 @@ boo( const int* a )
 
 === Const value/const reference type
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %typemap{const std::string}{simple};
@@ -66,9 +66,9 @@ void boo(const std::string& a);
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 foo( const std::string a )
@@ -98,7 +98,7 @@ boo( std::string* a )
 
 === Const value/const reference type via shortcut
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %typemap{const std::string};
@@ -111,9 +111,9 @@ void foo2(std::vector<double> a, std::vector<double>& b);
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 void
 foo( const std::string a )
@@ -157,7 +157,7 @@ foo2( std::vector< double > a, std::vector< double >* b )
 
 === Template type
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %typemap{const std::vector<int>&}{simple};
@@ -170,9 +170,9 @@ void boo(const std::map<int, std::string> a);
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 
 void
@@ -202,7 +202,7 @@ boo( const std::map< int, std::string > a )
     }
 === Template argument transformed to pointer
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 %package{Foo};
 
 %typemap{const std::vector<double>&}{reference}; // check type equality
@@ -212,9 +212,9 @@ void foo(const std::vector<double>& a);
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 
 void

--- a/t/075_types.t
+++ b/t/075_types.t
@@ -27,29 +27,13 @@ MODULE=XspTest PACKAGE=Foo
 int*
 foo()
   CODE:
-    try {
-      RETVAL = foo();
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = foo();
   OUTPUT: RETVAL
 
 int*
 boo( const int* a )
   CODE:
-    try {
-      RETVAL = boo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = boo( a );
   OUTPUT: RETVAL
 
 === Const value/const reference type
@@ -73,28 +57,12 @@ MODULE=XspTest PACKAGE=Foo
 void
 foo( const std::string a )
   CODE:
-    try {
-      foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    foo( a );
 
 void
 boo( std::string* a )
   CODE:
-    try {
-      boo( *( a ) );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    boo( *( a ) );
 
 === Const value/const reference type via shortcut
 --- xsp_stdout
@@ -118,41 +86,17 @@ MODULE=XspTest PACKAGE=Foo
 void
 foo( const std::string a )
   CODE:
-    try {
-      foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    foo( a );
 
 void
 boo( std::string* a )
   CODE:
-    try {
-      boo( *( a ) );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    boo( *( a ) );
 
 void
 foo2( std::vector< double > a, std::vector< double >* b )
   CODE:
-    try {
-      foo2( a, *( b ) );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    foo2( a, *( b ) );
 
 
 === Template type
@@ -178,28 +122,13 @@ MODULE=XspTest PACKAGE=Foo
 void
 foo( const std::vector< int >& a )
   CODE:
-    try {
-      foo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    foo( a );
 
 void
 boo( const std::map< int, std::string > a )
   CODE:
-    try {
-      boo( a );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    boo( a );
+
 === Template argument transformed to pointer
 --- xsp_stdout
 %module{XspTest};
@@ -220,12 +149,4 @@ MODULE=XspTest PACKAGE=Foo
 void
 foo( std::vector< double >* a )
   CODE:
-    try {
-      foo( *( a ) );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    foo( *( a ) );

--- a/t/075_types.t
+++ b/t/075_types.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 5;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/080_complex_typemap.t
+++ b/t/080_complex_typemap.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Complex typemap, type rename
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %typemap{int}{parsed}{
     %cpp_type{foobar};
@@ -26,9 +26,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 foobar
 Foo::foo( foobar a, void* b )
@@ -46,7 +46,7 @@ Foo::foo( foobar a, void* b )
 
 === Complex typemap, custom return value conversion
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %typemap{int}{parsed}{
     %call_function_code{% $CVar = fancy_conversion( $Call ) %};
@@ -60,9 +60,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a, int b )
@@ -80,7 +80,7 @@ Foo::foo( int a, int b )
 
 === Complex typemap, output code
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %typemap{int}{parsed}{
     %output_code{% $PerlVar = custom_code( $CVar ) %};
@@ -94,9 +94,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a, int b )
@@ -115,7 +115,7 @@ Foo::foo( int a, int b )
 
 === Complex typemap, cleanup code
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %typemap{int}{parsed}{
     %cleanup_code{% custom_code( $PerlVar, $CVar ) %};
@@ -129,9 +129,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a, int b )
@@ -151,7 +151,7 @@ Foo::foo( int a, int b )
 
 === Complex typemap, pre-call code
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %typemap{int}{parsed}{
     %precall_code{% custom_code( $PerlVar, $CVar ) %};
@@ -165,9 +165,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a, int b )
@@ -187,7 +187,7 @@ Foo::foo( int a, int b )
 
 === Complex typemap, output list code
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %typemap{int}{parsed}{
     %output_list{% PUTBACK; XPUSHi( $CVar ); SPAGAIN %};
@@ -201,9 +201,9 @@ class Foo
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a, int b )

--- a/t/080_complex_typemap.t
+++ b/t/080_complex_typemap.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 6;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/080_complex_typemap.t
+++ b/t/080_complex_typemap.t
@@ -33,15 +33,7 @@ MODULE=XspTest PACKAGE=Foo
 foobar
 Foo::foo( foobar a, void* b )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b );
   OUTPUT: RETVAL
 
 === Complex typemap, custom return value conversion
@@ -67,15 +59,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a, int b )
   CODE:
-    try {
-       RETVAL = fancy_conversion( THIS->foo( a, b ) ) ;
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+     RETVAL = fancy_conversion( THIS->foo( a, b ) ) ;
   OUTPUT: RETVAL
 
 === Complex typemap, output code
@@ -101,16 +85,8 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a, int b )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b );
+    RETVAL = THIS->foo( a, b );
        ST(0) = custom_code( RETVAL ) ;
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
   OUTPUT: RETVAL
 
 === Complex typemap, cleanup code
@@ -136,15 +112,7 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a, int b )
   CODE:
-    try {
-      RETVAL = THIS->foo( a, b );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b );
   OUTPUT: RETVAL
   CLEANUP:
      custom_code( ST(0), RETVAL ) ;
@@ -172,17 +140,9 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a, int b )
   CODE:
-    try {
        custom_code( ST(1), a ) ;
  custom_code( ST(2), b ) ;
-      RETVAL = THIS->foo( a, b );
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }
+    RETVAL = THIS->foo( a, b );
   OUTPUT: RETVAL
 
 === Complex typemap, output list code
@@ -208,13 +168,5 @@ MODULE=XspTest PACKAGE=Foo
 int
 Foo::foo( int a, int b )
   PPCODE:
-    try {
-      RETVAL = THIS->foo( a, b );
+    RETVAL = THIS->foo( a, b );
        PUTBACK; XPUSHi( RETVAL ); SPAGAIN ;
-    }
-    catch (std::exception& e) {
-      croak("Caught C++ exception of type or derived from 'std::exception': %s", e.what());
-    }
-    catch (...) {
-      croak("Caught C++ exception of unknown type");
-    }

--- a/t/090_exceptions.t
+++ b/t/090_exceptions.t
@@ -2,6 +2,7 @@
 
 use t::lib::XSP::Test;
 
+with_exception_handling();
 run_diff xsp_stdout => 'expected';
 
 __DATA__
@@ -32,6 +33,7 @@ foo( int a )
       croak("Caught C++ exception of unknown type");
     }
   OUTPUT: RETVAL
+
 === Basic exception declaration and catch
 --- xsp_stdout
 %module{XspTest};
@@ -405,3 +407,30 @@ Foo::buz( int a )
       croak("Caught C++ exception of unknown type");
     }
   OUTPUT: RETVAL
+
+=== Accessors don't generate exception code
+--- xsp_stdout
+%module{XspTest};
+
+class Foo
+{
+    int foo %get %set;
+};
+--- expected
+# XSP preamble
+
+
+MODULE=XspTest
+
+MODULE=XspTest PACKAGE=Foo
+
+int
+Foo::get_foo()
+  CODE:
+    RETVAL = THIS->foo;
+  OUTPUT: RETVAL
+
+void
+Foo::set_foo( int value )
+  CODE:
+    THIS->foo = value;

--- a/t/090_exceptions.t
+++ b/t/090_exceptions.t
@@ -1,8 +1,6 @@
 #!/usr/bin/perl -w
 
-use strict;
-use warnings;
-use t::lib::XSP::Test tests => 9;
+use t::lib::XSP::Test;
 
 run_diff xsp_stdout => 'expected';
 

--- a/t/090_exceptions.t
+++ b/t/090_exceptions.t
@@ -8,7 +8,7 @@ __DATA__
 
 === Basic exception declaration
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{std::exception}{stdmessage};
 
@@ -18,7 +18,7 @@ int foo(int a);
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 int
 foo( int a )
   CODE:
@@ -34,7 +34,7 @@ foo( int a )
   OUTPUT: RETVAL
 === Basic exception declaration and catch
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{stdmessage};
 
@@ -45,7 +45,7 @@ int foo(int a)
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 int
 foo( int a )
   CODE:
@@ -62,7 +62,7 @@ foo( int a )
 
 === Multiple exception declaration and catch
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{stdmessage};
 %exception{myException2}{SomeException2}{simple};
@@ -88,7 +88,7 @@ class Foo {
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 int
 foo( int a )
   CODE:
@@ -104,7 +104,7 @@ foo( int a )
   OUTPUT: RETVAL
 
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::bar( int a )
@@ -159,7 +159,7 @@ Foo::buz( int a )
 
 === 'code' exception
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{code}{% croak(e.what()); %};
 
@@ -170,7 +170,7 @@ int foo(int a)
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 int
 foo( int a )
   CODE:
@@ -187,7 +187,7 @@ foo( int a )
 
 === 'object' exception
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{object}{PerlClass};
 
@@ -198,7 +198,7 @@ int foo(int a)
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 int
 foo( int a )
   CODE:
@@ -220,7 +220,7 @@ foo( int a )
 
 === 'perlcode' exception
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{perlcode}{%some
 perl
@@ -233,7 +233,7 @@ int foo(int a)
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 int
 foo( int a )
   CODE:
@@ -260,7 +260,7 @@ foo( int a )
 
 === Class-wide catch with precedence test
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{stdmessage};
 %exception{myException2}{SomeException2}{stdmessage};
@@ -275,9 +275,9 @@ class Foo %catch{myException, myException3} {
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a )
@@ -301,7 +301,7 @@ Foo::foo( int a )
 
 === Catch nothing
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{stdmessage};
 %exception{myException3}{SomeException3}{stdmessage};
@@ -316,9 +316,9 @@ class Foo %catch{myException, myException3} {
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a )
@@ -350,7 +350,7 @@ Foo::bar( int a )
 
 === Catch nothing (via class)
 --- xsp_stdout
-%module{Foo};
+%module{XspTest};
 
 %exception{myException}{SomeException}{stdmessage};
 
@@ -366,9 +366,9 @@ class Foo %catch{nothing} {
 # XSP preamble
 
 
-MODULE=Foo
+MODULE=XspTest
 
-MODULE=Foo PACKAGE=Foo
+MODULE=XspTest PACKAGE=Foo
 
 int
 Foo::foo( int a )

--- a/t/lib/XSP/Test.pm
+++ b/t/lib/XSP/Test.pm
@@ -70,7 +70,7 @@ sub _munge_output($) {
 sub xsp_stdout {
     ExtUtils::XSpp::Typemap::reset_typemaps();
     @random_digits = @random_list;
-    my $d = ExtUtils::XSpp::Driver->new( string => shift );
+    my $d = ExtUtils::XSpp::Driver->new( string => shift, exceptions => 1 );
     my $out = $d->generate;
     ExtUtils::XSpp::Typemap::reset_typemaps();
 
@@ -81,7 +81,7 @@ sub xsp_file {
     ExtUtils::XSpp::Typemap::reset_typemaps();
     @random_digits = @random_list;
     my $name = Test::Base::filter_arguments();
-    my $d = ExtUtils::XSpp::Driver->new( string => shift );
+    my $d = ExtUtils::XSpp::Driver->new( string => shift, exceptions => 1 );
     my $out = $d->generate;
     ExtUtils::XSpp::Typemap::reset_typemaps();
 

--- a/t/lib/XSP/Test.pm
+++ b/t/lib/XSP/Test.pm
@@ -8,6 +8,13 @@ use Test::Base -Base;
 use Test::Differences;
 use ExtUtils::XSpp::Typemap;
 
+{
+    no warnings 'redefine';
+
+    # Test::Base is way too clever
+    *Test::Base::run_compare = sub { };
+}
+
 our @EXPORT = qw(run_diff);
 
 # allows running tests both from t and from the top directory
@@ -35,6 +42,8 @@ sub run_diff(@) {
 
         eq_or_diff( $b_got, $b_expected, $block->name);
     };
+
+    Test::More::done_testing();
 }
 
 use ExtUtils::XSpp;


### PR DESCRIPTION
This is for compatibility with ExtUtils::ParseXS 3.61+.

Fixes #4 (a.k.a RT 179739).